### PR TITLE
fix: rename per-field encryption options to avoid Mongoose v8.15+ CSFLE conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,15 @@ You also need to register your encryption functions once via `EncryptedString.se
 - `isEncrypted` — returns `true` if the string is already encrypted
 
 ```typescript
-const myEncrypt = (value: string): string => { /* ... */ }
-const myDecrypt = (value: string): string => { /* ... */ }
-const myIsEncrypted = (value: string): boolean => { /* ... */ }
+const myEncrypt = (value: string): string => {
+  /* ... */
+}
+const myDecrypt = (value: string): string => {
+  /* ... */
+}
+const myIsEncrypted = (value: string): boolean => {
+  /* ... */
+}
 
 // Not needed when using the plugin
 EncryptedString.setEncryptionFunctions({ encrypt: myEncrypt, decrypt: myDecrypt, isEncrypted: myIsEncrypted })
@@ -142,9 +148,11 @@ MongooseModule.forRootAsync({
 
 ### Per-Field Encryption Functions
 
-By default, all `EncryptedString` fields share the global encryption functions registered via `setEncryptionFunctions()` or the plugin. If you need different encryption logic per field — for example, using different KMS keys or different algorithms — you can pass `encrypt`, `decrypt`, and `isEncrypted` directly to the field's schema options.
+By default, all `EncryptedString` fields share the global encryption functions registered via `setEncryptionFunctions()` or the plugin. If you need different encryption logic per field — for example, using different KMS keys or different algorithms — you can pass `encryptFn`, `decryptFn`, and `isEncryptedFn` directly to the field's schema options.
 
 All three functions must be provided together. Providing only some of them will throw an error.
+
+> The option keys are suffixed with `Fn` to avoid conflict with Mongoose v8.15+'s built-in CSFLE [`encrypt`](https://mongoosejs.com/docs/encryption.html) property on `SchemaTypeOptions`.
 
 ```typescript
 @Schema()
@@ -156,9 +164,9 @@ export class User {
   // Uses a different KMS key for this field
   @Prop({
     type: EncryptedString,
-    encrypt: kmsB.encrypt,
-    decrypt: kmsB.decrypt,
-    isEncrypted: kmsB.isEncrypted,
+    encryptFn: kmsB.encrypt,
+    decryptFn: kmsB.decrypt,
+    isEncryptedFn: kmsB.isEncrypted,
   })
   ssn!: string
 }
@@ -195,9 +203,9 @@ await placeModel.create({ placeId: 'placeId', phone: [{ phoneNumber: 1234 }] })
 Validation and casting also apply to filter and update queries:
 
 ```typescript
-await placeModel.findOne({ phone: [{}] })                                          // ValidationError
-await placeModel.findOne({ phone: [{ phoneNumber: 1234 }] })                       // OK
-await placeModel.updateOne({ placeId: 'placeId' }, { $set: { phone: [{}] } })     // ValidationError
+await placeModel.findOne({ phone: [{}] }) // ValidationError
+await placeModel.findOne({ phone: [{ phoneNumber: 1234 }] }) // OK
+await placeModel.updateOne({ placeId: 'placeId' }, { $set: { phone: [{}] } }) // ValidationError
 await placeModel.updateOne({ placeId: 'placeId' }, { $set: { phone: [{ phoneNumber: 1234 }] } }) // OK
 ```
 
@@ -205,11 +213,11 @@ await placeModel.updateOne({ placeId: 'placeId' }, { $set: { phone: [{ phoneNumb
 
 Each field can operate in one of three encryption modes, configured with the `encryptionMode` option. The default is `'both'`.
 
-| Mode | Behavior |
-|------|----------|
-| `'both'` | Encrypts on write, decrypts on read (default) |
+| Mode            | Behavior                                               |
+| --------------- | ------------------------------------------------------ |
+| `'both'`        | Encrypts on write, decrypts on read (default)          |
 | `'encryptOnly'` | Encrypts on write, returns raw encrypted value on read |
-| `'decryptOnly'` | Skips encryption on write, decrypts on read |
+| `'decryptOnly'` | Skips encryption on write, decrypts on read            |
 
 `'decryptOnly'` is useful for gradual encryption removal: temporarily set the mode to `'decryptOnly'` so reads still decrypt existing data, but new writes are stored as plaintext. Once migration is complete, remove the encryption settings entirely.
 

--- a/lib/schemaType.ts
+++ b/lib/schemaType.ts
@@ -41,16 +41,17 @@ export class EncryptedString extends SchemaType {
     options?: SchemaTypeOptions<string> & {
       originalType?: any
       encryptionMode?: EncryptionMode
-      encrypt?: (value: string) => string
-      decrypt?: (value: string) => string
-      isEncrypted?: (value: string) => boolean
+      /** Per-field encrypt function. Suffixed with `Fn` to avoid conflict with Mongoose v8.15+ CSFLE `encrypt`. */
+      encryptFn?: (value: string) => string
+      decryptFn?: (value: string) => string
+      isEncryptedFn?: (value: string) => boolean
     },
   ) {
     // Strip per-field functions before passing to Mongoose super — Mongoose calls any option key
     // that matches an instance method name, which would trigger this.encrypt() before originalModel is set
     super(
       path,
-      { ...options, originalType: undefined, encrypt: undefined, decrypt: undefined, isEncrypted: undefined },
+      { ...options, originalType: undefined, encryptFn: undefined, decryptFn: undefined, isEncryptedFn: undefined },
       'EncryptedString',
     )
 
@@ -58,9 +59,9 @@ export class EncryptedString extends SchemaType {
     this.validatePerFieldEncryption(options)
     this.encryptionMode = options?.encryptionMode ?? 'both'
     this.originalType = options?.originalType ?? String
-    this.encryptFn = options?.encrypt
-    this.decryptFn = options?.decrypt
-    this.isEncryptedFn = options?.isEncrypted
+    this.encryptFn = options?.encryptFn
+    this.decryptFn = options?.decryptFn
+    this.isEncryptedFn = options?.isEncryptedFn
     this.originalModel = model(`${path}_${randomUUID()}`, this.createOriginalSchema())
 
     this.$conditionalHandlers = {
@@ -103,16 +104,16 @@ export class EncryptedString extends SchemaType {
   }
 
   private validatePerFieldEncryption(options?: {
-    encrypt?: (value: string) => string
-    decrypt?: (value: string) => string
-    isEncrypted?: (value: string) => boolean
+    encryptFn?: (value: string) => string
+    decryptFn?: (value: string) => string
+    isEncryptedFn?: (value: string) => boolean
   }) {
-    const provided = [options?.encrypt, options?.decrypt, options?.isEncrypted].filter(
+    const provided = [options?.encryptFn, options?.decryptFn, options?.isEncryptedFn].filter(
       (fn) => typeof fn === 'function',
     ).length
     if (provided > 0 && provided < 3) {
       throw new Error(
-        'Per-field encryption requires all three functions: encrypt, decrypt, isEncrypted. Provide all or none.',
+        'Per-field encryption requires all three functions: encryptFn, decryptFn, isEncryptedFn. Provide all or none.',
       )
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,14 +20,19 @@ export type MongooseFieldEncryption = (schema: Schema, options: MongooseFieldEnc
 /** Encryption mode. Defaults to `'both'`. */
 export type EncryptionMode = 'both' | 'encryptOnly' | 'decryptOnly'
 
-/** Per-field encryption functions. All three must be provided together or omitted entirely. */
+/**
+ * Per-field encryption functions. All three must be provided together or omitted entirely.
+ *
+ * Option keys are suffixed with `Fn` (e.g. `encryptFn`) to avoid conflict with
+ * Mongoose v8.15+'s built-in CSFLE `encrypt` property on `SchemaTypeOptions`.
+ */
 export interface PerFieldEncryptionOptions {
   /** Per-field string encryption function. Overrides the global encrypt for this field only. */
-  encrypt?: (value: string) => string
+  encryptFn?: (value: string) => string
   /** Per-field string decryption function. Overrides the global decrypt for this field only. */
-  decrypt?: (value: string) => string
+  decryptFn?: (value: string) => string
   /** Per-field check if string is encrypted. Overrides the global isEncrypted for this field only. */
-  isEncrypted?: (value: string) => boolean
+  isEncryptedFn?: (value: string) => boolean
 }
 
 declare module 'mongoose' {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-encrypt-fields",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Mongoose plugin and a custom schemaType to encrypt and decrypt individual fields in Nest.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/app/database/schemas/per-field-encryption.schema.ts
+++ b/test/app/database/schemas/per-field-encryption.schema.ts
@@ -26,9 +26,9 @@ export class PerFieldEncryptionSubDoc {
   /** Uses per-field encryption functions */
   @Prop({
     type: EncryptedString,
-    encrypt: encrypt2,
-    decrypt: decrypt2,
-    isEncrypted: isEncrypted2,
+    encryptFn: encrypt2,
+    decryptFn: decrypt2,
+    isEncryptedFn: isEncrypted2,
   })
   customField?: string
 }
@@ -46,22 +46,40 @@ export class PerFieldEncryption {
   /** Uses per-field encryption functions */
   @Prop({
     type: EncryptedString,
-    encrypt: encrypt2,
-    decrypt: decrypt2,
-    isEncrypted: isEncrypted2,
+    encryptFn: encrypt2,
+    decryptFn: decrypt2,
+    isEncryptedFn: isEncrypted2,
   })
   customField?: string
 
   /** Per-field encrypted Number */
-  @Prop({ type: EncryptedString, originalType: Number, encrypt: encrypt2, decrypt: decrypt2, isEncrypted: isEncrypted2 })
+  @Prop({
+    type: EncryptedString,
+    originalType: Number,
+    encryptFn: encrypt2,
+    decryptFn: decrypt2,
+    isEncryptedFn: isEncrypted2,
+  })
   customNumber?: number
 
   /** Per-field encrypted Object */
-  @Prop({ type: EncryptedString, originalType: GPS, encrypt: encrypt2, decrypt: decrypt2, isEncrypted: isEncrypted2 })
+  @Prop({
+    type: EncryptedString,
+    originalType: GPS,
+    encryptFn: encrypt2,
+    decryptFn: decrypt2,
+    isEncryptedFn: isEncrypted2,
+  })
   customObject?: GPS
 
   /** Per-field encrypted Array */
-  @Prop({ type: EncryptedString, originalType: [Number], encrypt: encrypt2, decrypt: decrypt2, isEncrypted: isEncrypted2 })
+  @Prop({
+    type: EncryptedString,
+    originalType: [Number],
+    encryptFn: encrypt2,
+    decryptFn: decrypt2,
+    isEncryptedFn: isEncrypted2,
+  })
   customArray?: number[]
 
   /** Subdocument containing per-field encrypted fields */

--- a/test/plugin.per-field-encryption.spec.ts
+++ b/test/plugin.per-field-encryption.spec.ts
@@ -211,14 +211,14 @@ describe('[plugin] per-field encryption', () => {
       const mongoose = require('mongoose')
       const { EncryptedString } = require('@lib')
 
-      // Only encrypt provided
+      // Only encryptFn provided
       expect(() => {
-        new mongoose.Schema({ field: { type: EncryptedString, encrypt: () => 'x' } })
+        new mongoose.Schema({ field: { type: EncryptedString, encryptFn: () => 'x' } })
       }).toThrow()
 
-      // encrypt and decrypt, but no isEncrypted
+      // encryptFn and decryptFn, but no isEncryptedFn
       expect(() => {
-        new mongoose.Schema({ field: { type: EncryptedString, encrypt: () => 'x', decrypt: () => 'x' } })
+        new mongoose.Schema({ field: { type: EncryptedString, encryptFn: () => 'x', decryptFn: () => 'x' } })
       }).toThrow()
     })
   })


### PR DESCRIPTION
Mongoose v8.15.0 added `encrypt?: EncryptSchemaTypeOptions` to `SchemaTypeOptions` for CSFLE support. This conflicts with our per-field `encrypt` option (`(value: string) => string`).

Renamed per-field option keys with `Fn` suffix to resolve the type conflict:

- `encrypt` → `encryptFn`
- `decrypt` → `decryptFn`
- `isEncrypted` → `isEncryptedFn`

Global encryption functions (`setEncryptionFunctions`, plugin options) are unchanged.

**BREAKING CHANGE:** Per-field encryption schema options must use the new key names.